### PR TITLE
[REFACTOR/#179] 외부 API 요청 트랜잭션 분리를 위한 Facade 패턴 도입

### DIFF
--- a/src/main/java/com/favoriteplace/app/member/Facade/AuthFacade.java
+++ b/src/main/java/com/favoriteplace/app/member/Facade/AuthFacade.java
@@ -1,0 +1,72 @@
+package com.favoriteplace.app.member.Facade;
+
+import com.favoriteplace.app.member.controller.dto.KaKaoSignUpRequestDto;
+import com.favoriteplace.app.member.controller.dto.MemberDto;
+import com.favoriteplace.app.member.controller.dto.MemberSignUpReqDto;
+import com.favoriteplace.app.member.controller.dto.TokenInfoDto;
+import com.favoriteplace.app.member.domain.Member;
+import com.favoriteplace.app.member.service.MemberService;
+import com.favoriteplace.app.member.service.TokenService;
+import com.favoriteplace.global.auth.kakao.KakaoClient;
+import com.favoriteplace.global.auth.provider.JwtTokenProvider;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class AuthFacade {
+    private final MemberService memberService;
+    private final TokenService tokenService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final KakaoClient kakaoClient;
+
+    public TokenInfoDto kakaoLogin(final String token) {
+        String email = kakaoClient.getUserInfo(token).kakaoAccount().email();
+        memberService.kakaoLogin(email);
+        return getTokenDto(email);
+    }
+
+    public MemberDto.MemberSignUpResDto kakaoSignUp(
+            final String token,
+            final KaKaoSignUpRequestDto memberSignUpReqDto,
+            final List<MultipartFile> images
+    ) throws IOException {
+        String email = kakaoClient.getUserInfo(token).kakaoAccount().email();
+        TokenInfoDto tokenDto = getTokenDto(email);
+        Member member = memberService.kakaoSignUp(email, memberSignUpReqDto, images);
+        tokenService.updateRefreshToken(member, tokenDto.refreshToken());
+        return MemberDto.MemberSignUpResDto.from(member, tokenDto);
+    }
+
+    public MemberDto.MemberSignUpResDto signup(
+            final MemberSignUpReqDto memberSignUpReqDto,
+            final List<MultipartFile> images
+    ) throws IOException {
+        Member member = memberService.signup(memberSignUpReqDto, images);
+        TokenInfoDto tokenDto = getTokenDto(member.getEmail());
+        tokenService.updateRefreshToken(member, tokenDto.refreshToken());
+        return MemberDto.MemberSignUpResDto.from(member, tokenDto);
+    }
+
+    public void logout(String accessToken) {
+        Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
+        String email = authentication.getName();
+        Long expiration = jwtTokenProvider.getExpiration(accessToken);
+        Member member = memberService.findMember(email);
+        tokenService.logoutAndInvalidateToken(member, expiration, accessToken);
+    }
+
+    private TokenInfoDto getTokenDto(String email) {
+        return TokenInfoDto.of(
+                jwtTokenProvider.issueAccessToken(email),
+                jwtTokenProvider.issueRefreshToken(email)
+        );
+    }
+}

--- a/src/main/java/com/favoriteplace/app/member/controller/MemberController.java
+++ b/src/main/java/com/favoriteplace/app/member/controller/MemberController.java
@@ -1,5 +1,6 @@
 package com.favoriteplace.app.member.controller;
 
+import com.favoriteplace.app.member.Facade.AuthFacade;
 import com.favoriteplace.app.member.controller.dto.TokenInfoDto;
 import com.favoriteplace.global.auth.provider.JwtTokenProvider;
 import com.favoriteplace.app.member.controller.dto.KaKaoSignUpRequestDto;
@@ -34,8 +35,9 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 public class MemberController {
-    private final MemberService memberService;
+    private final AuthFacade authFacade;
     private final MailSendService mailSendService;
+    private final MemberService memberService;
     private final JwtTokenProvider jwtTokenProvider;
     private final SecurityUtil securityUtil;
 
@@ -43,7 +45,7 @@ public class MemberController {
     public ResponseEntity<TokenInfoDto> kakaoLogin(
             @RequestHeader("Authorization") final String token
     ) {
-        return ResponseEntity.ok(memberService.kakaoLogin(token));
+        return ResponseEntity.ok(authFacade.kakaoLogin(token));
     }
 
     @PostMapping("/signup/kakao")
@@ -52,7 +54,7 @@ public class MemberController {
             @RequestPart(required = false) final List<MultipartFile> images,
             @RequestPart final KaKaoSignUpRequestDto data
     ) throws IOException {
-        return ResponseEntity.ok(memberService.kakaoSignUp(token, data, images));
+        return ResponseEntity.ok(authFacade.kakaoSignUp(token, data, images));
     }
 
     @PostMapping("/signup")
@@ -60,7 +62,7 @@ public class MemberController {
             @RequestPart(required = false) List<MultipartFile> images,
             @RequestPart MemberSignUpReqDto data
     ) throws IOException {
-        return ResponseEntity.ok(memberService.signup(data, images));
+        return ResponseEntity.ok(authFacade.signup(data, images));
     }
 
     @PostMapping("/signup/email")
@@ -97,8 +99,7 @@ public class MemberController {
     @PostMapping("/logout")
     public ResponseEntity<String> logout(HttpServletRequest request) {
         String accessToken = securityUtil.resolveToken(request);
-        memberService.logout(accessToken);
-
+        authFacade.logout(accessToken);
         return ResponseEntity.ok("로그아웃 되었습니다.");
     }
 }

--- a/src/main/java/com/favoriteplace/app/member/domain/Member.java
+++ b/src/main/java/com/favoriteplace/app/member/domain/Member.java
@@ -79,7 +79,7 @@ public class Member extends BaseTimeEntity {
     public static Member create(
             String nickname, String email,
             boolean snsAllow, String introduction,
-            String profileImage, Item titleItem)
+            String profileImage, Item titleItem, LoginType loginType)
     {
         return Member.builder()
                 .nickname(nickname)
@@ -88,7 +88,7 @@ public class Member extends BaseTimeEntity {
                 .description(introduction)
                 .profileImageUrl(profileImage)
                 .point(0L)
-                .loginType(LoginType.KAKAO)
+                .loginType(loginType)
                 .profileTitle(titleItem)
                 .status(MemberStatus.Y)
                 .build();

--- a/src/main/java/com/favoriteplace/app/member/service/MailSendService.java
+++ b/src/main/java/com/favoriteplace/app/member/service/MailSendService.java
@@ -31,8 +31,6 @@ public class MailSendService {
 
     private final RedisUtil redisUtil;
 
-
-    //임의의 6자리 양수를 반환합니다.
     public void makeRandomNumber() {
         Random r = new Random();
         String randomNumber = "";
@@ -43,23 +41,21 @@ public class MailSendService {
         authNumber = Integer.parseInt(randomNumber);
     }
 
-    //mail을 어디서 보내는지, 어디로 보내는지 , 인증 번호를 html 형식으로 어떻게 보내는지 작성합니다.
     public MemberDto.EmailSendResDto joinEmail(String email) {
         makeRandomNumber();
         String setFrom = host; // email-config에 설정한 자신의 이메일 주소를 입력
         String toMail = email;
-        String title = "[최애의 장소] 회원 가입 인증 이메일 입니다."; // 이메일 제목
+        String title = "[최애의 장소] 회원 가입 인증 이메일 입니다.";
         String content =
-                "최애의 장소를 방문해주셔서 감사합니다." +    //html 형식으로 작성 !
+                "최애의 장소를 방문해주셔서 감사합니다." +
                         "<br><br>" +
                         "인증 번호는 " + authNumber + "입니다." +
                         "<br>" +
-                        "인증번호를 올바르게 입력해주세요 :)"; //이메일 내용 삽입
+                        "인증번호를 올바르게 입력해주세요 :)";
         mailSend(setFrom, toMail, title, content);
         return new MemberDto.EmailSendResDto(authNumber);
     }
 
-    //이메일을 전송합니다.
     public void mailSend(String setFrom, String toMail, String title, String content) {
         //JavaMailSender 객체를 사용하여 MimeMessage 객체를 생성
         MimeMessage message = mailSender.createMimeMessage();

--- a/src/main/java/com/favoriteplace/app/member/service/MemberService.java
+++ b/src/main/java/com/favoriteplace/app/member/service/MemberService.java
@@ -1,11 +1,9 @@
 package com.favoriteplace.app.member.service;
 
-import static com.favoriteplace.global.exception.ErrorCode.TOKEN_NOT_VALID;
 import static com.favoriteplace.global.exception.ErrorCode.USER_ALREADY_EXISTS;
 import static com.favoriteplace.global.exception.ErrorCode.USER_NOT_FOUND;
 
 import com.favoriteplace.app.member.controller.dto.MemberSignUpReqDto;
-import com.favoriteplace.app.member.controller.dto.TokenInfoDto;
 import com.favoriteplace.app.member.domain.Member;
 import com.favoriteplace.app.item.domain.Item;
 import com.favoriteplace.app.member.controller.dto.UserInfoResponseDto;
@@ -14,6 +12,7 @@ import com.favoriteplace.app.member.controller.dto.MemberDto;
 import com.favoriteplace.app.member.controller.dto.MemberDto.EmailDuplicateResDto;
 import com.favoriteplace.app.member.controller.dto.MemberDto.EmailSendReqDto;
 import com.favoriteplace.app.item.repository.ItemRepository;
+import com.favoriteplace.app.member.domain.enums.LoginType;
 import com.favoriteplace.app.member.repository.MemberRepository;
 import com.favoriteplace.global.auth.kakao.KakaoClient;
 import com.favoriteplace.global.auth.provider.JwtTokenProvider;
@@ -22,12 +21,11 @@ import com.favoriteplace.global.s3Image.AmazonS3ImageManager;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import lombok.RequiredArgsConstructor;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,74 +34,55 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Slf4j
 public class MemberService {
 
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
-    private final JwtTokenProvider jwtTokenProvider;
     private final AmazonS3ImageManager amazonS3ImageManager;
     private final ItemRepository itemRepository;
-    private final RedisTemplate redisTemplate;
-    private final KakaoClient kakaoClient;
 
-    public TokenInfoDto kakaoLogin(final String token) {
-        String userEmail = getUserEmailFromKakao(token);
-
-        // 최초 로그인이라면 회원가입 API로 통신하도록
-        Member member = findMember(userEmail);
-
-        return issueToken(userEmail);
+    public void kakaoLogin(final String email) {
+        Member member = findMember(email);
     }
 
     @Transactional
-    public MemberDto.MemberSignUpResDto kakaoSignUp(
-            final String token,
+    public Member kakaoSignUp(
+            final String email,
             final KaKaoSignUpRequestDto memberSignUpReqDto,
             final List<MultipartFile> images
     ) throws IOException {
-
-        String userEmail = getUserEmailFromKakao(token);
-
-        memberRepository.findByEmail(userEmail)
+        memberRepository.findByEmail(email)
                 .ifPresent(a -> {
                     throw new RestApiException(USER_ALREADY_EXISTS);
                 });
-
         String profileImage = getProfileImageFromRequest(images);
-
         Item titleItem = getDefaultProfileItem();
-
-        Member member = saveUser(memberSignUpReqDto.nickname(), userEmail,
-                memberSignUpReqDto.snsAllow(), memberSignUpReqDto.introduction(),
-                profileImage, titleItem);
-
-        TokenInfoDto tokenInfo = issueToken(userEmail);
-        member.updateRefreshToken(tokenInfo.refreshToken());
-
-        return MemberDto.MemberSignUpResDto.from(member, tokenInfo);
-
+        Member member = saveUser(
+                memberSignUpReqDto.nickname(),
+                email,
+                memberSignUpReqDto.snsAllow(),
+                memberSignUpReqDto.introduction(),
+                profileImage,
+                titleItem,
+                LoginType.KAKAO
+        );
+        return member;
     }
 
     @Transactional
-    public MemberDto.MemberSignUpResDto signup(
+    public Member signup(
             final MemberSignUpReqDto memberSignUpReqDto,
             final List<MultipartFile> images
     ) throws IOException {
-
         String password = passwordEncoder.encode(memberSignUpReqDto.password());
-
         Item titleItem = getDefaultProfileItem();
-
         String profileImage = getProfileImageFromRequest(images);
-
         Member member = saveUser(memberSignUpReqDto.nickname(), memberSignUpReqDto.email(),
                 memberSignUpReqDto.snsAllow(), memberSignUpReqDto.introduction(),
-                profileImage, titleItem);
-
-        TokenInfoDto tokenInfo= issueToken(member.getEmail());
-        member.updateRefreshToken(tokenInfo.refreshToken());
-
-        return MemberDto.MemberSignUpResDto.from(member, tokenInfo);
+                profileImage, titleItem, LoginType.SELF);
+        member.updatePassword(password);
+        return member;
     }
 
     public String uploadProfileImage(MultipartFile profileImage) throws IOException {
@@ -113,14 +92,12 @@ public class MemberService {
     public MemberDto.EmailDuplicateResDto emailDuplicateCheck(EmailSendReqDto emailSendReqDto) {
         String email = emailSendReqDto.getEmail();
         Boolean isExists = memberRepository.findByEmail(email).isPresent();
-
         return new EmailDuplicateResDto(isExists);
     }
 
     @Transactional
     public void setNewPassword(String email, String password) {
         Member member = findMember(email);
-
         String newPassword = passwordEncoder.encode(password);
         member.updatePassword(newPassword);
     }
@@ -132,49 +109,25 @@ public class MemberService {
         return null;
     }
 
-    @Transactional
-    public void logout(String accessToken) {
-        /*1. Access Token 검증 */
-        if (!jwtTokenProvider.validateToken(accessToken)) {
-            new RestApiException(TOKEN_NOT_VALID);
-        }
-
-        Authentication authentication = jwtTokenProvider.getAuthentication(accessToken);
-        Member member = findMember(authentication.getName());
-
-        if (member.getRefreshToken() != null && !member.getRefreshToken().isEmpty()) {
-            member.deleteRefreshToken(member.getRefreshToken());
-        }
-
-        /* 해당 asscess token 유효시간을 계산해서 blacklist로 저장 */
-        Long expriation = jwtTokenProvider.getExpiration(accessToken);
-        redisTemplate.opsForValue()
-                .set(accessToken, "logout", expriation, TimeUnit.MICROSECONDS);
-    }
-
-    private Member findMember(final String email) {
+    public Member findMember(final String email) {
         return memberRepository.findByEmail(email)
                 .orElseThrow(() -> new RestApiException(USER_NOT_FOUND));
-    }
-
-    private String getUserEmailFromKakao(String token) {
-        return kakaoClient.getUserInfo(token).kakaoAccount().email();
     }
 
     private Item getDefaultProfileItem() {
         return itemRepository.findByName("새싹회원").get();
     }
 
-    private TokenInfoDto issueToken(String email) {
-        return jwtTokenProvider.generateToken(email);
-    }
-
     private Member saveUser(
             String nickname, String email,
             boolean snsAllow, String introduction,
-            String profileImage, Item titleItem)
-    {
-        Member member = Member.create(nickname, email, snsAllow, introduction, profileImage, titleItem);
+            String profileImage, Item titleItem, LoginType loginType) {
+        Member member =
+                Member.create(
+                        nickname, email,
+                        snsAllow, introduction,
+                        profileImage, titleItem, loginType
+                );
         return memberRepository.save(member);
     }
 

--- a/src/main/java/com/favoriteplace/app/member/service/TokenService.java
+++ b/src/main/java/com/favoriteplace/app/member/service/TokenService.java
@@ -1,0 +1,41 @@
+package com.favoriteplace.app.member.service;
+
+import com.favoriteplace.app.member.domain.Member;
+import com.favoriteplace.global.auth.provider.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TokenService {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Transactional
+    public void updateRefreshToken(Member member, String refreshToken) {
+        member.updateRefreshToken(refreshToken);
+    }
+
+    @Transactional
+    public void logoutAndInvalidateToken(Member member, Long expiration, String accessToken) {
+        deleteRefreshToken(member);
+        blacklistAccessToken(expiration, accessToken);
+    }
+
+    private void deleteRefreshToken (Member member) {
+        if (member.getRefreshToken() != null && !member.getRefreshToken().isEmpty()) {
+            member.deleteRefreshToken(member.getRefreshToken());
+        }
+    }
+
+    private void blacklistAccessToken(Long expiration, String accessToken) {
+        redisTemplate.opsForValue()
+                .set(accessToken, "logout", expiration, TimeUnit.MICROSECONDS);
+    }
+
+}

--- a/src/main/java/com/favoriteplace/global/auth/handler/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/favoriteplace/global/auth/handler/CustomAuthenticationSuccessHandler.java
@@ -43,8 +43,10 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
         Member member = memberRepository.findByEmail(email)
                 .orElseThrow(() -> new RestApiException(ErrorCode.USER_NOT_FOUND));
 
-        TokenInfoDto tokenInfo = jwtTokenProvider.generateToken(member.getEmail());
+        String issuedRefreshToken = jwtTokenProvider.issueRefreshToken(member.getEmail());
+        String issuedAccessToken = jwtTokenProvider.issueRefreshToken(member.getEmail());
 
+        TokenInfoDto tokenInfo = TokenInfoDto.of(issuedAccessToken, issuedRefreshToken);
         member.updateRefreshToken(tokenInfo.refreshToken());
 
         response.setContentType(APPLICATION_JSON_VALUE);

--- a/src/main/java/com/favoriteplace/global/util/RedisUtil.java
+++ b/src/main/java/com/favoriteplace/global/util/RedisUtil.java
@@ -2,6 +2,7 @@ package com.favoriteplace.global.util;
 
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Service;
@@ -9,17 +10,17 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class RedisUtil {
-    private final StringRedisTemplate redisTemplate;//Redis에 접근하기 위한 Spring의 Redis 템플릿 클래스
+    private final RedisTemplate<String, String> redisTemplate;
 
-    public String getData(String key){//지정된 키(key)에 해당하는 데이터를 Redis에서 가져오는 메서드
+    public String getData(String key){
         ValueOperations<String,String> valueOperations = redisTemplate.opsForValue();
         return valueOperations.get(key);
     }
-    public void setData(String key, String value){//지정된 키(key)에 값을 저장하는 메서드
+    public void setData(String key, String value){
         ValueOperations<String,String> valueOperations = redisTemplate.opsForValue();
         valueOperations.set(key, value);
     }
-    public void setDataExpire(String key, String value, long duration){//지정된 키(key)에 값을 저장하고, 지정된 시간(duration) 후에 데이터가 만료되도록 설정하는 메서드
+    public void setDataExpire(String key, String value, long duration){
         ValueOperations<String,String> valueOperations = redisTemplate.opsForValue();
         Duration expireDuration = Duration.ofSeconds(duration);
         valueOperations.set(key, value, expireDuration);

--- a/src/main/java/com/favoriteplace/global/websocket/JwtChannelInterceptor.java
+++ b/src/main/java/com/favoriteplace/global/websocket/JwtChannelInterceptor.java
@@ -51,10 +51,7 @@ public class JwtChannelInterceptor implements ChannelInterceptor {
                 String jwt = bearerToken.startsWith("Bearer ") ? bearerToken.substring(7) : bearerToken;
 
                 try {
-                    // JWT 토큰 검증
-                    if (!jwtProvider.validateToken(jwt)) {
-                        throw new RestApiException(ErrorCode.USER_NOT_AUTHOR);
-                    }
+                    jwtProvider.validateToken(jwt);
 
                     Authentication authentication = jwtProvider.getAuthentication(jwt);
 

--- a/src/test/java/com/favoriteplace/app/member/facade/AuthFacadeTest.java
+++ b/src/test/java/com/favoriteplace/app/member/facade/AuthFacadeTest.java
@@ -1,0 +1,79 @@
+package com.favoriteplace.app.member.facade;
+
+import com.favoriteplace.app.member.Facade.AuthFacade;
+import com.favoriteplace.app.member.controller.dto.AuthKakaoLoginDto;
+import com.favoriteplace.app.member.controller.dto.TokenInfoDto;
+import com.favoriteplace.app.member.domain.Member;
+import com.favoriteplace.app.member.domain.enums.LoginType;
+import com.favoriteplace.app.member.service.MemberService;
+import com.favoriteplace.global.auth.kakao.KakaoClient;
+import com.favoriteplace.global.auth.provider.JwtTokenProvider;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthFacadeTest {
+
+    @Mock
+    private MemberService memberService;
+
+    @Mock
+    private KakaoClient kakaoClient;
+
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @InjectMocks
+    private AuthFacade authFacade;
+
+    private static Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = Member.create(
+                "yoon",
+                "email",
+                true,
+                "자기소개",
+                "image",
+                null,
+                LoginType.SELF
+        );
+    }
+
+    @Test
+    @DisplayName("카카오 로그인 - 카카오로부터 사용자 정보를 받아오고, 토큰을 생성하여 반환한다.")
+    void kakaoLoginTest() {
+        // given
+        when(kakaoClient.getUserInfo(anyString()))
+                .thenReturn(new AuthKakaoLoginDto(new AuthKakaoLoginDto.KakaoAccount("email")));
+
+        doNothing().when(memberService).kakaoLogin("email");
+
+        when(jwtTokenProvider.issueAccessToken("email")).thenReturn("accessToken");
+        when(jwtTokenProvider.issueRefreshToken("email")).thenReturn("refreshToken");
+
+        // when
+        TokenInfoDto result = authFacade.kakaoLogin("kakaoAccessToken");
+
+        // then
+        assertThat(result.accessToken()).isEqualTo("accessToken");
+        assertThat(result.refreshToken()).isEqualTo("refreshToken");
+
+        verify(kakaoClient).getUserInfo("kakaoAccessToken");
+        verify(memberService).kakaoLogin("email");
+        verify(jwtTokenProvider).issueAccessToken("email");
+        verify(jwtTokenProvider).issueRefreshToken("email");
+    }
+}

--- a/src/test/java/com/favoriteplace/app/repository/MemberRepositoryTest.java
+++ b/src/test/java/com/favoriteplace/app/repository/MemberRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.favoriteplace.app.repository;
 
 import com.favoriteplace.app.member.domain.Member;
+import com.favoriteplace.app.member.domain.enums.LoginType;
 import com.favoriteplace.app.member.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +36,8 @@ class MemberRepositoryTest {
                 true,
                 "자기소개",
                 "image",
-                null);
+                null,
+                LoginType.SELF);
     }
 
     @Test


### PR DESCRIPTION
# 📄 Work Description
- 외부 API 요청 트랜잭션 분리를 위한 Facade 패턴 도입


# ⚙️ ISSUE
- closed #179


# 💬 To Reviewers

##  🔆 외부 API 요청 트랜잭션 분리를 위한 Facade 패턴 도입

`AS-IS`
- 외부 API 요청(카카오 로그인)과 비즈니스 로직(db에 멤버 저장)이 한 트래잭션 안에서 모두 이루어지고 있는 상황이었어요.
- 외부 API 통신은 비교적 시간이 오래 걸리며, 멤버를 저장하는 로직과 같은 트랜잭션 범위 안에 포함되면 DB 커넥션을 가지고 있는 시간과 트랜잭션이 활성화된 시간이 불필요하게 길어지게 되어 성능이 저하될 수 있다는 문제점이 있었습니다!


`TO-BE`
- Controller와 service단 사이에 Facade계층을 두어 외부 통신은 트랜잭션을 타지 않고, service단에는 @Transactional을 붙여서 비즈니스 로직은 트랜잭션을 타도록 했습니다!
- 추가적으로 `MemberService`와 `TokenService`를 분리했어요.
  - MemberSerivce의 역할이 멤버 도메인 관련된 비즈니스 로직과 토큰 관련된 비즈니스 로직을 모두 책임하고 있어, 관심사 분리하다고 느꼈어요. 따라서 아래와 같이 분리했으며, 각 클래스의 역할은 아래와 같아요!
  - `MemberService`: 회원 도메인 중심의 핵심 로직 (회원 가입, 정보 저장, 검증 등)
  - `TokenService:` 인증 관련 로직 (토큰 저장, 무효화, 로그아웃)
  - `Facade`: 흐름 제어 및 외부 API 연계
  
 <br/>

<img width="896" alt="image" src="https://github.com/user-attachments/assets/3c36c8ef-7471-42d3-b93e-aa651291e686" />


<br/>
<br/>


## 🔆 트래잭션 분리에 대한 테스트 실행
- 외부 API 요청과 db 저장 비즈니스 로직을 트랜잭션에서 분리시킴에 따라, 각각 트랜잭션을 타지 않는지, 타는지를 확인하기 위해 로그를 찍어서 테스트를 진행했어요!

```java
        String email = kakaoClient.getUserInfo(token).kakaoAccount().email();  //트랜잭션 타지 않아야함
        memberService.kakaoLogin(email);   //트랜잭션 타야함
```

- MemberService 클래스
```java
@Slf4j
@Service
public class MemberService {

    @Transactional
    public TokenInfoDto kakaoLogin(String email) {
        log.info("트랜잭션 활성화 여부: {}", TransactionSynchronizationManager.isActualTransactionActive());
        ...
    }
}
```

- FeignClientConfig 클래스
  - FeignClient가 호출될 때 request 보내기 직전에 이 Interceptor가 요청을 가로채서, Feign 요청 시 트랜잭션 활성 여부를 확인하고자 했습니다!
```java
@Configuration
@Slf4j
public class FeignClientConfig {

    @Bean
    public ErrorDecoder errorDecoder() {
        return new CustomErrorDecoder();
    }

    @Bean
    public RequestInterceptor transactionLoggingInterceptor() {
        return requestTemplate -> {
            boolean isTransactionActive = TransactionSynchronizationManager.isActualTransactionActive();
            log.info("Feign 요청 시 트랜잭션 활성 여부: {}", isTransactionActive);
        };
    }
```
<br/>


- 원하는대로 잘 동작하는 것 확인했어요!
![image](https://github.com/user-attachments/assets/9bcc8b3e-9c1c-4b4d-a122-4109c809a7dd)



# 🔗 Reference
https://xxeol.tistory.com/48

_책임 분리가 모호한 부분이나, 우려되는 지점?, 궁금증 등등 아무 코멘트 다 좋습니당 ㅎㅎ_