### PR TITLE
[FEAT/#181] 기존 배포 방식을 Docker로 Migration

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -22,8 +22,16 @@ jobs:
           java-version: '17'
           distribution: 'temurin'
 
-      - name: 'Grant execute permission for gradlew'
-        run: chmod +x gradlew
+      - name: Gradle cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle
+
 
       - name: Create application.yml
         run: |
@@ -33,4 +41,4 @@ jobs:
           cat ./src/main/resources/application.yml
 
       - name: 'Build with Gradle'
-        run: ./gradlew build
+        run: ./gradlew build -x test

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -25,5 +25,12 @@ jobs:
       - name: 'Grant execute permission for gradlew'
         run: chmod +x gradlew
 
+      - name: Create application.yml
+        run: |
+          mkdir -p ./src/main/resources
+          touch ./application.yml
+          echo "${{ secrets.YML }}" > ./src/main/resources/application.yml
+          cat ./src/main/resources/application.yml
+
       - name: 'Build with Gradle'
         run: ./gradlew build

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches: [ "develop" ]
 
-
 permissions:
   contents: read
 
@@ -14,13 +13,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Set up JDK 11
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+
+      - name: 'Set up JDK 17'
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee
-        with:
-          arguments: clean build -x test
+
+      - name: 'Grant execute permission for gradlew'
+        run: chmod +x gradlew
+
+      - name: 'Build with Gradle'
+        run: ./gradlew build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,71 +1,81 @@
-name: Spring Boot & Gradle CI/CD
+name: CICD-MAIN
 
 on:
   push:
-    branches: [ main ]
+    branches: [ "main" ]
 
-
-# 본인이 설정한 값을 여기서 채워넣습니다.
-# 리전, 버킷 이름, CodeDeploy 앱 이름, CodeDeploy 배포 그룹 이름
 env:
   AWS_REGION: ap-northeast-2
-  S3_BUCKET_NAME: favoriteplace-bucket
-  CODE_DEPLOY_APPLICATION_NAME: favorite-place-app
-  CODE_DEPLOY_DEPLOYMENT_GROUP_NAME: favorite-deploy-group
-
-permissions:
-  contents: read
+  ECR_REGISTRY: 859043921675.dkr.ecr.ap-northeast-2.amazonaws.com
+  ECR_REPOSITORY: moemoe
+  IMAGE_TAG: ${{ github.sha }}
 
 jobs:
-  deploy:
-    name: Deploy
+  ci:
     runs-on: ubuntu-latest
-    environment: production
 
     steps:
-    # (1) 기본 체크아웃
-    - name: Checkout
-      uses: actions/checkout@v3
+      - name: Checkout source code
+        uses: actions/checkout@v3
 
-    # (2) JDK 11 세팅
-    - name: Set up JDK 17
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'temurin'
-        java-version: '17'
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
 
-    # (3) Gradle build (Test 제외)
-    - name: Grant execute permission for gradlew
-      run: chmod +x ./gradlew
+      - name: Gradle Cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
-    - name: Build with Gradle
-      uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee
-      with:
-        arguments: clean build -x test
+      - name: Create application.yml
+        run: |
+          mkdir -p ./src/main/resources
+          touch ./application.yml
+          echo "${{ secrets.YML }}" > ./src/main/resources/application.yml
+          cat ./src/main/resources/application.yml
 
-    # (4) AWS 인증 (IAM 사용자 Access Key, Secret Key 활용)
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ env.AWS_REGION }}
+      - name: Build with Gradle
+        run: |
+          chmod +x ./gradlew
+          ./gradlew clean build -x test --parallel --build-cache --daemon
 
-    # (5) 빌드 결과물을 S3 버킷에 업로드
-    - name: Upload to AWS S3
-      run: |
-        aws deploy push \
-          --application-name ${{ env.CODE_DEPLOY_APPLICATION_NAME }} \
-          --ignore-hidden-files \
-          --s3-location s3://$S3_BUCKET_NAME/$GITHUB_SHA.zip \
-          --source .
+      - name: 🔐 Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
 
-    # (6) S3 버킷에 있는 파일을 대상으로 CodeDeploy 실행
-    - name: Deploy to AWS EC2 from S3
-      run: |
-        aws deploy create-deployment \
-          --application-name ${{ env.CODE_DEPLOY_APPLICATION_NAME }} \
-          --deployment-config-name CodeDeployDefault.AllAtOnce \
-          --deployment-group-name ${{ env.CODE_DEPLOY_DEPLOYMENT_GROUP_NAME }} \
-          --s3-location bucket=$S3_BUCKET_NAME,key=$GITHUB_SHA.zip,bundleType=zip \
-          --file-exists-behavior OVERWRITE
+      - name: 🔑 Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: 🐳 Build, tag, and push Docker image
+        run: |
+          docker build -t $ECR_REPOSITORY:$IMAGE_TAG .
+          docker tag $ECR_REPOSITORY:$IMAGE_TAG $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+
+  cd:
+    needs: ci
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🚀 Deploy via SSH
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SERVER_IP }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_KEY }}
+          script: |
+            cd ~
+            ./deploy.sh ${{ github.sha }}
+            docker image prune -f
+

--- a/DockerFile
+++ b/DockerFile
@@ -1,0 +1,12 @@
+FROM eclipse-temurin:17-jdk-alpine
+
+WORKDIR /app
+
+COPY build/libs/favoriteplace-0.0.1-SNAPSHOT.jar ./app.jar
+
+RUN apk add --no-cache tzdata && \
+    cp /usr/share/zoneinfo/Asia/Seoul /etc/localtime && \
+    echo "Asia/Seoul" > /etc/timezone && \
+    apk del tzdata
+
+CMD ["java", "-Duser.timezone=Asia/Seoul", "-jar", "-Dspring.profiles.active=prod", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,9 @@ dependencies {
 
 	// Jackson (Date/Time Serialization)
 	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
+	//actuator
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+services:
+  redis:
+    container_name: redis
+    image: redis:alpine
+    ports:
+      - "6379:6379"
+    networks:
+      - app-network
+
+  blue:
+    container_name: moemoe-blue
+    image: 859043921675.dkr.ecr.ap-northeast-2.amazonaws.com/moemoe:latest
+    expose:
+      - 8080
+    ports:
+      - "8081:8080"
+    environment:
+      - TZ=Asia/Seoul
+    depends_on:
+      - redis
+    networks:
+      - app-network
+
+  green:
+    container_name: moemoe-green
+    image: 859043921675.dkr.ecr.ap-northeast-2.amazonaws.com/moemoe:latest
+    expose:
+      - 8080
+    ports:
+      - "8082:8080"
+    environment:
+      - TZ=Asia/Seoul
+    depends_on:
+      - redis
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge


### PR DESCRIPTION
# 📄 Work Description
- 기존 AWS S3 + CodeDeploy로 배포하던 방식을 Docker 컨테이너를 사용해서 배포하도록 마이그레이션했습니다.


# ⚙️ ISSUE
- closed #181 


# 📷 Screenshot
 - 동영상, 사진, 로그 등등
 - ex) 큐알 성공 이미지, 스웨거, 포스트맨 등


# 💬 To Reviewers
### ⚡️ SSH 터널링
- 저번 스터디 때 말씀드린대로, 보안상의 이점을 가져가기 위해 RDS를 private subnet으로 분리 시켰는데요! 
- 이에 따라 Datagrip에서 RDS에 바로 접근하지 못하게 되어서, SSH 터널링를 통해 EC2를 통해 Private Subnet 내부의 RDS로 연결하는 터널을 생성해줘야 한다고 합니다..!!
   - SSH 터널링은 저도 해본적은 없는데, 그렇게 까다롭진 않은 것 같아서 cd 잘 되는거 보고 터널링 작업도 이어서 진행할게요!

### ⚡️ docker compose 
Redis도 Docker 컨테이너로 띄우고, docker-compose.yml에 포함하여 함께 관리하도록 구성했어요.


# 🔗 Reference
https://cobinding.tistory.com/272

https://velog.io/@dbfla0628/AWS-Github-Actions%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-ECR-%EB%A0%88%EC%A7%80%EC%8A%A4%ED%8A%B8%EB%A6%AC-Push-%EC%9E%90%EB%8F%99%ED%99%94%ED%95%98%EA%B8%B0

+ 어떤 의견이든 궁금증이든 뭐든 환영입니당 ㅎㅎ
+ci/cd 잘 되는지는 앞으로 확인해봐야 알 것 같습니당 !! 트슈 생기면 정리해둘게요~~
